### PR TITLE
Fix: search string is unexpectedly replaced with another (more old) search string

### DIFF
--- a/Source/RSA.Core/Model/StorageCategories.Predefined1.cs
+++ b/Source/RSA.Core/Model/StorageCategories.Predefined1.cs
@@ -16,12 +16,19 @@ namespace RSA.Core {
         public static SearchTerm Outfit {
 			get { return TermFor(CategoryID_Outfit); }
 		}
-		
+
+		public const string CategoryID_Preview = "Preview";
+		public static SearchTerm Preview
+		{
+			get { return TermFor(CategoryID_Preview); }
+		}
+
 		static SearchCategories() {
 			CachedTerms = new Dictionary<string, SearchTerm>{
 				{ CategoryID_Storage, new SearchTerm(CategoryID_Storage)},
 				{ CategoryID_Bill, new SearchTerm(CategoryID_Bill)},
 				{ CategoryID_Outfit, new SearchTerm(CategoryID_Outfit)},
+				{ CategoryID_Preview, new SearchTerm(CategoryID_Preview)},
 			};
 		}
     }

--- a/Source/RSA.Core/Model/ThingFilterCache.cs
+++ b/Source/RSA.Core/Model/ThingFilterCache.cs
@@ -1,0 +1,34 @@
+﻿using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace RSA.Core.Model
+{
+	public static class ThingFilterCache
+	{
+		public static void Set(string key, ThingFilter filter)
+        {
+			CachedFilters[key] = filter;
+		}
+
+		public static string KeyByFilter([NotNull] ThingFilter filter)
+		{
+			var res = CachedFilters.Where(x => x.Value == filter).ToList();
+			if (res.Count > 0)
+				return res[0].Key;
+
+			return null;
+		}
+
+		private static readonly IDictionary<string, ThingFilter> CachedFilters = new Dictionary<string, ThingFilter>{
+			{ SearchCategories.CategoryID_Storage, null},
+			{ SearchCategories.CategoryID_Bill, null},
+			{ SearchCategories.CategoryID_Outfit, null},
+			{ SearchCategories.CategoryID_Preview, null},
+		};
+	}
+}

--- a/Source/RSA.Core/RSA.Core.csproj
+++ b/Source/RSA.Core/RSA.Core.csproj
@@ -57,7 +57,7 @@
     <Reference Include="UnityEngine.InputLegacyModule">
       <HintPath>$(RimworldManagedDir11)\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
-    </Reference>    
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EventArgs.cs" />
@@ -74,6 +74,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>StorageCategories.Predefined.tt</DependentUpon>
     </Compile>
+    <Compile Include="Model\ThingFilterCache.cs" />
     <Compile Include="Patches\FilterSearch_InjectSearchBox.cs" />
     <Compile Include="Patches\ThingFilter_InjectFilter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/RSA.Core/RSACoreMod.cs
+++ b/Source/RSA.Core/RSACoreMod.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using HarmonyLib;
+using RSA.Core.Model;
 using RSA.Languages;
 using UnityEngine;
 using Verse;
@@ -75,7 +76,7 @@ namespace RSA.Core
             Text.Font = GameFont.Tiny;
             Widgets.Label(new Rect(rect.x, rect.y, rect.width * 0.5f, Text.LineHeight), RSACoreKeys.RSACore_Preview.Translate());
 
-            ThingFilterUtil.QueueNextInvocationSearch(SearchCategories.TermFor("Settings"));
+            ThingFilterCache.Set(SearchCategories.CategoryID_Preview, RSACoreMod.filter);
             ThingFilterUI.DoThingFilterConfigWindow(
                 new Rect(rect.width - 300f, rect.y, 300f, previewHeight),
                 ref scrollPosition,

--- a/Source/RSA.Core/ThingFilterUtil.cs
+++ b/Source/RSA.Core/ThingFilterUtil.cs
@@ -13,20 +13,5 @@ namespace RSA.Core {
         public static void QueueNextInvocationFilter([NotNull]Func<TreeNode_ThingCategory, TreeNode_ThingCategory> projection) {
             ThingFilter_InjectFilter.Projections.Enqueue(projection);
         }
-
-        /// <summary>
-        /// Queue up an embedding of a search input filter for the next invocation of <see cref="ThingFilterUI.DoThingFilterConfigWindow"/>.
-        /// </summary>
-        /// <param name="term"><see cref="SearchTerm"/> to use.</param>
-        /// <param name="watermark">Use this parameter to change the search boxes default watermark/seach hint</param>
-        public static void QueueNextInvocationSearch([NotNull] SearchTerm term, string watermark = null) {
-            FilterSearch_InjectSearchBox.searchOptions.Enqueue(
-                new SearchOptions
-                {
-                    Term = term,
-                    Watermark = watermark
-                });
-            FilterSearch_InjectSearchBox.showSearchCount++;
-        }
     }
 }

--- a/Source/RSA/Patches/Bills/Dialog_BillConfig_DoWindowContents.cs
+++ b/Source/RSA/Patches/Bills/Dialog_BillConfig_DoWindowContents.cs
@@ -1,6 +1,9 @@
 ﻿using HarmonyLib;
 using RimWorld;
 using RSA.Core;
+using RSA.Core.Model;
+using RSA.Core.Util;
+using System;
 using UnityEngine;
 using Verse;
 
@@ -8,13 +11,17 @@ namespace RSA {
     [HarmonyPatch(typeof(Dialog_BillConfig), nameof(Dialog_BillConfig.DoWindowContents))]
     class Dialog_BillConfig_DoWindowContents
     {
+        private static Func<Dialog_BillConfig, Bill_Production> GetBill = Access.GetFieldGetter<Dialog_BillConfig, Bill_Production>("bill");
 
         [HarmonyPrefix]
-        public static void Before_DoWindowContents(Rect inRect) {
+        public static void Before_DoWindowContents(Dialog_BillConfig __instance, Rect inRect) {
             if (!Settings.EnableCraftingFilter)
                 return;
 
-            ThingFilterUtil.QueueNextInvocationSearch(SearchCategories.Bill);
+            if (ReferenceEquals(__instance.GetType().Assembly, typeof(ITab_Storage).Assembly)) {
+                var bill = GetBill(__instance);
+                ThingFilterCache.Set(SearchCategories.CategoryID_Bill, bill.ingredientFilter);
+            }
         }
     }
 }

--- a/Source/RSA/Patches/HaulingHysteresis_InjectControls.cs
+++ b/Source/RSA/Patches/HaulingHysteresis_InjectControls.cs
@@ -17,18 +17,13 @@ namespace StorageSearch {
         private const float HysteresisHeight = 30f;
         private const float HysteresisBlockHeight = 35f;
 
-        internal static volatile int showHysteresisCount;
-
         private static Queue<StorageSettings> _settingsQueue = new Queue<StorageSettings>();
 
         internal static Queue<StorageSettings> SettingsQueue => _settingsQueue;
 
         [HarmonyPrefix]
         public static void Before_DoThingFilterConfigWindow(ref object __state, ref Rect rect) {
-            bool showHysteresis = (showHysteresisCount-- > 0) && _settingsQueue.Count != 0;
-            showHysteresisCount = Math.Max(0, showHysteresisCount);
-
-            if (showHysteresis)
+            if (_settingsQueue.Count != 0)
             {                
                 DoHysteresisBlock(new Rect(0f, rect.yMax - HysteresisHeight, rect.width, HysteresisHeight), _settingsQueue.Dequeue());
                 rect= new Rect(rect.x, rect.y, rect.width, rect.height - HysteresisBlockHeight);            

--- a/Source/RSA/Patches/Outfits/DialogManageOutfits.cs
+++ b/Source/RSA/Patches/Outfits/DialogManageOutfits.cs
@@ -4,6 +4,7 @@ using System.Reflection.Emit;
 using HarmonyLib;
 using RimWorld;
 using RSA.Core;
+using RSA.Core.Model;
 using RSA.Core.Util;
 using UnityEngine;
 
@@ -19,14 +20,16 @@ namespace RSA {
         }
 
         [HarmonyPrefix]
-        public static void Before_DoWindowContents(Rect inRect, Dialog_ManageOutfits __instance) {
-            if (GetSelectedOutfit(__instance) == null)
+        public static void Before_DoWindowContents(Dialog_ManageOutfits __instance, Rect inRect) {
+            Outfit outfit = GetSelectedOutfit(__instance);
+            if (outfit == null)
                 return;
 
             if (!Settings.EnableOutfitFilter)
                 return;
-            
-            ThingFilterUtil.QueueNextInvocationSearch(SearchCategories.Outfit);
+
+            if (__instance.GetType().Assembly == typeof(Dialog_ManageOutfits).Assembly)
+                ThingFilterCache.Set(SearchCategories.CategoryID_Outfit, outfit.filter);
         }
     }
 }

--- a/Source/RSA/Patches/Storage/ITab_Storage_FillTab.cs
+++ b/Source/RSA/Patches/Storage/ITab_Storage_FillTab.cs
@@ -6,6 +6,7 @@ using System.Reflection.Emit;
 using HarmonyLib;
 using RimWorld;
 using RSA.Core;
+using RSA.Core.Model;
 using RSA.Core.Util;
 using StorageSearch;
 using UnityEngine;
@@ -26,15 +27,13 @@ namespace RSA
 
         [HarmonyPrefix]
         public static void Before_ITab_Storage_FillTab(ITab_Storage __instance) {
-            ThingFilterUtil.QueueNextInvocationSearch(SearchCategories.Storage);
-
             if (ReferenceEquals(__instance.GetType().Assembly, typeof(ITab_Storage).Assembly))
             {
                 // only show hysteresis option for non derived (non-custom) storage(s)
-                HaulingHysteresis_InjectControls.showHysteresisCount++;
 
-                IStoreSettingsParent selStoreSettingsParent =  GetSelStoreSettingsParent(__instance);
-                HaulingHysteresis_InjectControls.SettingsQueue.Enqueue(selStoreSettingsParent.GetStoreSettings());
+                StorageSettings storeSettings = GetSelStoreSettingsParent(__instance).GetStoreSettings();
+                ThingFilterCache.Set(SearchCategories.CategoryID_Storage, storeSettings.filter);
+                HaulingHysteresis_InjectControls.SettingsQueue.Enqueue(storeSettings);
             }
         }
     }


### PR DESCRIPTION
The bug looks like an unexpected replacement of the search string with another string (introduced earlier). It was also observed that the search string for storage replaces by search string from crafting or assignments, and vice versa.

This PR replaces the current code (based on Queue) to Dictionary, which is much less error prone when multithreading is apllied.

Баг выглядит как неожиданная замена поисковой строки другой строкой (введенной ранее). Также наблюдалось, что в поисковую строку складов попадает строка из крафта или назначений, и наоборот.

Этот PR заменяет текущую систему (основанную на Queue) на Dictionary, который гораздо менее подвержен ошибкам при многопоточном выполнении кода.